### PR TITLE
Enhance TimeGuardian with Conditional Logging Based on Execution Time

### DIFF
--- a/timeguardian/decorators.py
+++ b/timeguardian/decorators.py
@@ -1,4 +1,3 @@
-# decorators.py
 import time
 import logging
 from functools import wraps
@@ -10,24 +9,29 @@ configure_logging()
 
 class TimeGuardian:
     @staticmethod
-    def measure(_func=None, *, name=None):
+    def measure(_func=None, *, name=None, logTimeLimit=None):
         """
-        A decorator to measure and log the execution time of a function.
+        A decorator to measure and log the execution time of a function. Logs only if execution time exceeds logTimeLimit.
 
         Parameters:
-        _func (callable, optional): The function to be decorated. If not provided, the decorator can be used with arguments.
-        name (str, optional): A custom name to log with the execution time. If not provided, only the time is logged.
+        _func (callable, optional): The function to be decorated.
+        name (str, optional): A custom name to log with the execution time.
+        logTimeLimit (int, optional): The execution time limit in milliseconds. Logs only if the execution time exceeds this limit.
 
         Returns:
-        callable: A wrapper function that adds time measurement functionality to the decorated function.
+        callable: A wrapper function that adds time measurement functionality.
 
         Usage:
         @TimeGuardian.measure
         def my_function():
             # function implementation
-            
+
         @TimeGuardian.measure(name="CustomName")
         def another_function():
+            # function implementation
+
+        @TimeGuardian.measure(logTimeLimit=200) # logTimeLimit is in milliseconds 
+        def limited_function():
             # function implementation
         """
         def decorator(func):
@@ -39,15 +43,17 @@ class TimeGuardian:
                 except Exception as e:
                     end = time.time()
                     logger.error(f"Exception in {func.__name__}: {e}")
-                    logger.info(f"Elapsed time until exception: {(end - start) * 1000:.3f}ms")
-                    raise  # Re-raises the caught exception
+                    elapsed_time = (end - start) * 1000
+                    if logTimeLimit is None or elapsed_time > logTimeLimit:
+                        logger.info(f"Elapsed time until exception: {elapsed_time:.3f}ms")
+                    raise
                 else:
                     end = time.time()
                     elapsed_time = (end - start) * 1000
-                    if name:
-                        logger.info(f'{name} - Elapsed time: {elapsed_time:.3f}ms')
-                    else:
-                        logger.info(f'Elapsed time: {elapsed_time:.3f}ms')
+                    if logTimeLimit is None or elapsed_time > logTimeLimit:
+                        log_message = f'{name} - ' if name else ''
+                        log_message += f'Elapsed time: {elapsed_time:.3f}ms'
+                        logger.info(log_message)
 
                     return result
             return wrapper


### PR DESCRIPTION
- Extend the TimeGuardian.measure decorator to accept an optional logTimeLimit parameter.
- Modify logging behavior to conditionally log execution time only if it exceeds the specified limit.
- Maintain backward compatibility by allowing the use of the decorator without specifying logTimeLimit.
- Update method documentation to reflect the new functionality and usage examples.