### PR TITLE
Add Tests for logTimeLimit Feature in TimeGuardian

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,3 +24,19 @@ def function_that_raises():
     def function():
         raise ValueError("Test Error")
     return function
+
+@pytest.fixture
+def fast_function():
+    @TimeGuardian.measure(logTimeLimit=200)
+    def function():
+        time.sleep(0.05)  # 50ms, under the logTimeLimit
+        return "fast"
+    return function
+
+@pytest.fixture
+def slow_function():
+    @TimeGuardian.measure(logTimeLimit=200)
+    def function():
+        time.sleep(0.3)  # 300ms, over the logTimeLimit
+        return "slow"
+    return function

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -19,3 +19,15 @@ def test_decorator_with_exception(function_that_raises, mocker):
     with pytest.raises(ValueError):
         function_that_raises()
     mock_logger.error.assert_called_with(ANY)
+
+def test_fast_function_logs_nothing(fast_function, mocker):
+    mock_logger = mocker.patch('timeguardian.decorators.logger')
+    result = fast_function()
+    assert result == "fast"
+    mock_logger.info.assert_not_called()
+
+def test_slow_function_logs_time(slow_function, mocker):
+    mock_logger = mocker.patch('timeguardian.decorators.logger')
+    result = slow_function()
+    assert result == "slow"
+    mock_logger.info.assert_called_with(ANY)


### PR DESCRIPTION
- Implemented two new pytest fixtures:  and .
-  tests the scenario where execution time is below the logTimeLimit threshold, verifying that logging does not occur.
-  tests the scenario where execution time exceeds the logTimeLimit threshold, ensuring that logging is performed.
- Both tests use the  parameter in the TimeGuardian decorator and mock the logger to check for the expected behavior.
- Enhanced test coverage to validate the conditional logging feature based on execution time.