### PR TITLE
Add global unit setting for time and memory in TimeGuardian

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,36 @@ def monitored_function():
     # function implementation
 ```
 
+## Setting Global Units for Time and Memory Measurement
+
+The TimeGuardian package allows you to set global units for time and memory measurements. This feature enables you to customize how the execution time and memory usage are reported.
+
+### Usage
+
+1. **Set the Units**: Use `TimeGuardian.set_time_unit(unit)` and `TimeGuardian.set_memory_unit(unit)` to set the global units for time and memory measurement. The `unit` parameter should be a string indicating the desired unit (e.g., 'ms' for milliseconds, 's' for seconds, 'bytes' for bytes, 'KB' for kilobytes, 'MB' for megabytes).
+
+2. **Decorate Functions**: Apply the `@TimeGuardian.measure` decorator to your functions. This decorator will use the globally set units to measure and log the execution time and memory usage.
+
+### Example
+
+```python
+from decorators import TimeGuardian
+
+# Set the units for time and memory measurements
+TimeGuardian.set_time_unit('ms')  # Set time unit to milliseconds
+TimeGuardian.set_memory_unit('MB')  # Set memory unit to megabytes
+
+@TimeGuardian.measure(elapsed=True, memory=True, name="Sample Function")
+def sample_function():
+    # Function implementation
+    ...
+
+# Call the decorated function
+sample_function()
+```
+
+In this example, `sample_function` is measured and logged in milliseconds for time and megabytes for memory usage.
+
 ## Contributing
 
 Contributions to TimeGuardian are welcome!

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="timeguardian",
-    version="0.0.5",
+    version="0.0.6",
     author="Aldin Cebo",
     author_email="ceboaldin@gmail.com",
     description="TimeGuardian is a package for execution time measurement",

--- a/timeguardian/decorators.py
+++ b/timeguardian/decorators.py
@@ -11,6 +11,40 @@ logger = logging.getLogger("TimeGuardian")
 configure_logging()
 
 class TimeGuardian:
+    # Class variables to store the units for time and memory
+    time_unit = 'ms'  # default unit milliseconds
+    memory_unit = 'bytes'  # default unit bytes
+
+    @classmethod
+    def set_time_unit(cls, unit):
+        """ Set the global unit for time measurement. """
+        cls.time_unit = unit
+
+    @classmethod
+    def set_memory_unit(cls, unit):
+        """ Set the global unit for memory measurement. """
+        cls.memory_unit = unit
+
+    @staticmethod
+    def convert_time(time_in_seconds):
+        """ Convert time from seconds to the set unit. """
+        if TimeGuardian.time_unit == 'ms':
+            return time_in_seconds * 1000  # Convert to milliseconds
+        elif TimeGuardian.time_unit == 's':
+            return time_in_seconds  # Already in seconds
+        # Add more unit conversions here
+
+    @staticmethod
+    def convert_memory(memory_in_bytes):
+        """ Convert memory from bytes to the set unit. """
+        if TimeGuardian.memory_unit == 'bytes':
+            return memory_in_bytes  # Already in bytes
+        elif TimeGuardian.memory_unit == 'KB':
+            return memory_in_bytes / 1024  # Convert to kilobytes
+        elif TimeGuardian.memory_unit == 'MB':
+            return memory_in_bytes / (1024 * 1024)  # Convert to megabytes
+        # Add more unit conversions here
+
     @staticmethod
     def measure(_func=None, *, name: str = None, elapsed: bool = True, memory: bool = False) -> callable:
         """
@@ -48,15 +82,15 @@ class TimeGuardian:
                         finally:
                             if memory:
                                 end_memory = psutil.Process().memory_info().rss
-                                memory_usage = end_memory - start_memory
+                                memory_usage = TimeGuardian.convert_memory(end_memory - start_memory)
                                 log_message = f'{name} - ' if name else ''
-                                log_message += f'Memory usage: {memory_usage} bytes'
+                                log_message += f'Memory usage: {memory_usage} {TimeGuardian.memory_unit}'
                                 logger.info(log_message)
                             if elapsed:
                                 end_time = time.time()
-                                elapsed_time = (end_time - start_time) * 1000
+                                elapsed_time = TimeGuardian.convert_time(end_time - start_time)
                                 log_message = f'{name} - ' if name else ''
-                                log_message += f'Elapsed time: {elapsed_time:.3f}ms'
+                                log_message += f'Elapsed time: {elapsed_time} {TimeGuardian.time_unit}'
                                 logger.info(log_message)
                         return result
                     except Exception as e:
@@ -75,15 +109,15 @@ class TimeGuardian:
                         finally:
                             if memory:
                                 end_memory = psutil.Process().memory_info().rss
-                                memory_usage = end_memory - start_memory
+                                memory_usage = TimeGuardian.convert_memory(end_memory - start_memory)
                                 log_message = f'{name} - ' if name else ''
-                                log_message += f'Memory usage: {memory_usage} bytes'
+                                log_message += f'Memory usage: {memory_usage} {TimeGuardian.memory_unit}'
                                 logger.info(log_message)
                             if elapsed:
                                 end_time = time.time()
-                                elapsed_time = (end_time - start_time) * 1000
+                                elapsed_time = TimeGuardian.convert_time(end_time - start_time)
                                 log_message = f'{name} - ' if name else ''
-                                log_message += f'Elapsed time: {elapsed_time:.3f}ms'
+                                log_message += f'Elapsed time: {elapsed_time} {TimeGuardian.time_unit}'
                                 logger.info(log_message)
                         return result
                     except Exception as e:
@@ -127,15 +161,15 @@ class TimeGuardian:
                         finally:
                             end_time = time.time()
                             end_memory = psutil.Process().memory_info().rss
-                            elapsed_time = (end_time - start_time) * 1000
-                            memory_usage = end_memory - start_memory
+                            elapsed_time = TimeGuardian.convert_time(end_time - start_time)
+                            memory_usage = TimeGuardian.convert_memory(end_memory - start_memory)
                             if elapsed is not None and elapsed_time > elapsed:
                                 log_message = f'{name} - ' if name else ''
-                                log_message += f'Elapsed time: {elapsed_time:.3f}ms'
+                                log_message += f'Elapsed time: {elapsed_time} {TimeGuardian.time_unit}'
                                 logger.info(log_message)
                             if memory is not None and memory_usage > memory:
                                 log_message = f'{name} - ' if name else ''
-                                log_message += f'Memory usage: {memory_usage} bytes'
+                                log_message += f'Memory usage: {memory_usage} {TimeGuardian.memory_unit}'
                                 logger.info(log_message)
                         return result
                     except Exception as e:
@@ -152,15 +186,15 @@ class TimeGuardian:
                         finally:
                             end_time = time.time()
                             end_memory = psutil.Process().memory_info().rss
-                            elapsed_time = (end_time - start_time) * 1000
-                            memory_usage = end_memory - start_memory
+                            elapsed_time = TimeGuardian.convert_time(end_time - start_time)
+                            memory_usage = TimeGuardian.convert_memory(end_memory - start_memory)
                             if elapsed is not None and elapsed_time > elapsed:
                                 log_message = f'{name} - ' if name else ''
-                                log_message += f'Elapsed time: {elapsed_time:.3f}ms'
+                                log_message += f'Elapsed time: {elapsed_time} {TimeGuardian.time_unit}'
                                 logger.info(log_message)
                             if memory is not None and memory_usage > memory:
                                 log_message = f'{name} - ' if name else ''
-                                log_message += f'Memory usage: {memory_usage} bytes'
+                                log_message += f'Memory usage: {memory_usage} {TimeGuardian.memory_unit}'
                                 logger.info(log_message)
 
                         return result


### PR DESCRIPTION
Enhanced the TimeGuardian class in decorators.py to allow users to globally set their preferred units for time (milliseconds, seconds) and memory (bytes, KB, MB) measurements. Updated README.md to include documentation and examples for this new feature. This enhancement makes the TimeGuardian package more flexible and user-friendly by providing customizable measurement units.